### PR TITLE
Add WordMeadow English vocabulary themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ A curated collection of English learning resources, tools, and materials for lan
 
 - [LinGo](https://www.reddit.com/r/languagelearning/comments/187kqcy/lingo_a_free_and_open_source_textbased_language/) – A terminal-based, open-source language learning tool that helps you learn languages while reading texts.
 - [Tatoeba](https://en.wikipedia.org/wiki/Tatoeba) – A large collection of example sentences with translations contributed by the community.
+- [WordMeadow English themes](https://wordmeadow.app/learn/english/from/spanish/themes) – Visual English vocabulary theme cards grouped by everyday topics.


### PR DESCRIPTION
Hi, thanks for curating this English learning resources list.

I would like to suggest adding WordMeadow as a language-learning tool for English vocabulary practice. The link points to English vocabulary themes for Spanish speakers and keeps the entry focused on topic-based vocabulary learning.

If another section, language path, or wording would fit better, I am happy to revise it. Thanks for taking a look.